### PR TITLE
- Fix PHP installation issue on Dockerfile due to PHP 7.2 get removed on PMMP Jenkins. 

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -29,11 +29,11 @@ RUN apt-get update && \
 RUN	mkdir -p /data /minecraft
 WORKDIR /minecraft
 
-# Grab the pre-built PHP 7.2 distribution from PMMP
-RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.2-Aggregate/lastSuccessfulBuild/artifact/PHP-7.2-Linux-x86_64.tar.gz > /minecraft/PHP-7.2-Linux-x86_64.tar.gz && \
+# Grab the pre-built PHP 7.3 distribution from PMMP
+RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.3-Aggregate/lastSuccessfulBuild/artifact/PHP-7.3-Linux-x86_64.tar.gz > /minecraft/PHP-7.3-Linux-x86_64.tar.gz && \
   cd /minecraft && \
-	tar -xvf PHP-7.2-Linux-x86_64.tar.gz && \
-	rm PHP-7.2-Linux-x86_64.tar.gz
+	tar -xvf PHP-7.3-Linux-x86_64.tar.gz && \
+	rm PHP-7.3-Linux-x86_64.tar.gz
 
 # Grab the Specific version PHAR
 RUN wget -q -O - https://github.com/pmmp/PocketMine-MP/releases/download/3.6.1/PocketMine-MP.phar > /minecraft/PocketMine-MP.phar

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -29,11 +29,11 @@ RUN apt-get update && \
 RUN	mkdir -p /data /minecraft
 WORKDIR /minecraft
 
-# Grab the pre-built PHP 7.2 distribution from PMMP
-RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.2-Aggregate/lastSuccessfulBuild/artifact/PHP-7.2-Linux-x86_64.tar.gz > /minecraft/PHP-7.2-Linux-x86_64.tar.gz && \
+# Grab the pre-built PHP 7.3 distribution from PMMP
+RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.3-Aggregate/lastSuccessfulBuild/artifact/PHP-7.3-Linux-x86_64.tar.gz > /minecraft/PHP-7.3-Linux-x86_64.tar.gz && \
   cd /minecraft && \
-	tar -xvf PHP-7.2-Linux-x86_64.tar.gz && \
-	rm PHP-7.2-Linux-x86_64.tar.gz
+	tar -xvf PHP-7.3-Linux-x86_64.tar.gz && \
+	rm PHP-7.3-Linux-x86_64.tar.gz
 
 # Grab the Specific version PHAR
 RUN wget -q -O - https://github.com/pmmp/PocketMine-MP/releases/download/3.8.2/PocketMine-MP.phar > /minecraft/PocketMine-MP.phar

--- a/3.9/Dockerfile
+++ b/3.9/Dockerfile
@@ -29,14 +29,14 @@ RUN apt-get update && \
 RUN	mkdir -p /data /minecraft
 WORKDIR /minecraft
 
-# Grab the pre-built PHP 7.2 distribution from PMMP
-RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.2-Aggregate/lastSuccessfulBuild/artifact/PHP-7.2-Linux-x86_64.tar.gz > /minecraft/PHP-7.2-Linux-x86_64.tar.gz && \
+# Grab the pre-built PHP 7.3 distribution from PMMP
+RUN wget -q -O - https://jenkins.pmmp.io/job/PHP-7.3-Aggregate/lastSuccessfulBuild/artifact/PHP-7.3-Linux-x86_64.tar.gz > /minecraft/PHP-7.3-Linux-x86_64.tar.gz && \
   cd /minecraft && \
-	tar -xvf PHP-7.2-Linux-x86_64.tar.gz && \
-	rm PHP-7.2-Linux-x86_64.tar.gz
+	tar -xvf PHP-7.3-Linux-x86_64.tar.gz && \
+	rm PHP-7.3-Linux-x86_64.tar.gz
 
 # Grab the Specific version PHAR
-RUN wget -q -O - https://github.com/pmmp/PocketMine-MP/releases/download/3.9.1/PocketMine-MP.phar > /minecraft/PocketMine-MP.phar
+RUN wget -q -O - https://github.com/pmmp/PocketMine-MP/releases/download/3.9.5/PocketMine-MP.phar > /minecraft/PocketMine-MP.phar
 
 # Grab the start script and make it executable
 RUN wget -q -O - https://raw.githubusercontent.com/pmmp/PocketMine-MP/master/start.sh > /minecraft/start.sh && \


### PR DESCRIPTION
*All Dockerfiles now download PHP 7.3 from PMMP Jenkins.

- Set Dockerfile for version 3.9 to pull latest 3.9.5 of PMMP.